### PR TITLE
support dactyle

### DIFF
--- a/.github/workflows/build-ergohaven.yml
+++ b/.github/workflows/build-ergohaven.yml
@@ -34,6 +34,7 @@ jobs:
         qmk compile -kb ergohaven/planeta/rev1 -km v1
         qmk compile -kb ergohaven/planeta -km v2
         qmk compile -kb ergohaven/macropad -km v1
+        qmk compile -kb ergohaven/classic_dactyl -km vial
 
     - uses: actions/upload-artifact@v4
       name: Upload

--- a/keyboards/ergohaven/classic_dactyl/keymaps/vial/config.h
+++ b/keyboards/ergohaven/classic_dactyl/keymaps/vial/config.h
@@ -1,0 +1,3 @@
+#define VIAL_UNLOCK_COMBO_ROWS { 0, 0 }
+#define VIAL_UNLOCK_COMBO_COLS { 0, 1 }
+#define VIAL_KEYBOARD_UID {0x74, 0x2A, 0xFA, 0x6B, 0xEB, 0x6E, 0x5B, 0x33}

--- a/keyboards/ergohaven/classic_dactyl/keymaps/vial/vial.json
+++ b/keyboards/ergohaven/classic_dactyl/keymaps/vial/vial.json
@@ -1,10 +1,11 @@
 {
-    
+
     "name": "timboard",
     "manufacturer": "Timba_XD",
     "vendorId": "0x444D",
     "productId": "0x3436",
     "matrix": {"rows": 12, "cols":6},
+    #include "keyboards/ergohaven/vial_custom_keycodes.json"
     "layouts": {
         "keymap": [
   [

--- a/keyboards/ergohaven/classic_dactyl/rules.mk
+++ b/keyboards/ergohaven/classic_dactyl/rules.mk
@@ -18,3 +18,7 @@ CAPS_WORD_ENABLE = yes
 REPEAT_KEY_ENABLE = yes
 AUTO_SHIFT_ENABLE = yes
 
+SRC += keyboards/ergohaven/ergohaven_rgb.c
+SRC += keyboards/ergohaven/ergohaven.c
+SRC += keyboards/ergohaven/ergohaven_ruen.c
+SRC += keyboards/ergohaven/hid.c


### PR DESCRIPTION
<!---

    If you are submitting a Vial-enabled keymap for a keyboard in QMK:

    - Keymaps will not be accepted with VIAL_INSECURE=yes.
    - Avoid changing keyboard-level code if possible. (ex: switching the encoder pins in info.json)
    - Please name your keymap "vial". Personal keymaps are not accepted at this time.
      - If your Vial keymap only works for a specific keyboard revision, place it under that revision's folder. (ex: keyboards/planck/rev6_drop/keymaps/vial and keyboards/planck/ez/glow/keymaps/vial)

    If you are submitting a new keyboard with keymaps:

    - If you are also submitting this keyboard to QMK, please try to submit mostly the same code to both repos if possible.
    - If you are not submitting this keyboard to QMK, only include "default" and "vial" keymaps. VIA firmware can no longer be built by this repository.

    ------

    For all keyboard and keymap submissions:

    As the submitter, you are ultimately responsible for maintaining the keyboards/keymaps you submit.
    Vial contributors will try to fix compilation issues as updates are made, but are not always familiar with and often can't test specific keymaps/keyboards.

    Vial is decentralized, so inclusion in the vial-qmk repository is optional. Unmaintained keymaps/keyboards which are broken and cannot be fixed without extensive rework or strong familiarity with the hardware may be removed from this repository, with or without warning.

    ------

    For core changes, please explain what you are changing and why.

    Before submitting a PR, delete the entirety of this comment and document your changes.
-->
